### PR TITLE
(feature): Add "instance" id to Config Access

### DIFF
--- a/configd/src/application/get_config.rs
+++ b/configd/src/application/get_config.rs
@@ -14,11 +14,14 @@ pub struct GetConfigCommand {
     pub config_id: String,
     #[serde(skip_deserializing)]
     pub source: Option<String>,
+    #[serde(skip_deserializing)]
+    pub instance: Option<String>,
 }
 
 #[derive(Serialize)]
 pub struct ConfigAccessDto {
     pub source: String,
+    pub instance: String,
     pub timestamp: DateTime<Utc>,
 }
 
@@ -57,8 +60,10 @@ impl GetConfig {
 
         if let Some(mut schema) = self.schema_repository.find_by_id(&schema_id).await? {
             let config_id = Id::new(cmd.config_id)?;
+            let source = cmd.source.map(Id::new).transpose()?;
+            let instance = cmd.instance.map(Id::new).transpose()?;
 
-            let config = schema.get_config(&config_id, cmd.source)?;
+            let config = schema.get_config(&config_id, source, instance)?;
 
             let res = GetConfigResponse {
                 schema_id: schema_id.to_string(),
@@ -72,6 +77,7 @@ impl GetConfig {
                     .iter()
                     .map(|access| ConfigAccessDto {
                         source: access.source().to_string(),
+                        instance: access.instance().to_string(),
                         timestamp: *access.timestamp(),
                     })
                     .collect(),

--- a/configd/src/application/get_config.rs
+++ b/configd/src/application/get_config.rs
@@ -23,6 +23,7 @@ pub struct ConfigAccessDto {
     pub source: String,
     pub instance: String,
     pub timestamp: DateTime<Utc>,
+    pub previous: Option<DateTime<Utc>>,
 }
 
 #[derive(Serialize)]
@@ -79,6 +80,7 @@ impl GetConfig {
                         source: access.source().to_string(),
                         instance: access.instance().to_string(),
                         timestamp: *access.timestamp(),
+                        previous: access.previous().copied(),
                     })
                     .collect(),
                 created_at: *config.timestamps().created_at(),

--- a/configd/src/application/get_schema.rs
+++ b/configd/src/application/get_schema.rs
@@ -57,7 +57,7 @@ impl GetSchema {
                         id: config.id().to_string(),
                         name: config.name().to_string(),
                         valid: config.is_valid(),
-                        checksum: hex::encode(config.checksum()),
+                        checksum: config.checksum().to_string(),
                         created_at: *config.timestamps().created_at(),
                         updated_at: *config.timestamps().updated_at(),
                         version: config.version().value(),

--- a/configd/src/domain/access.rs
+++ b/configd/src/domain/access.rs
@@ -1,22 +1,33 @@
 use chrono::{DateTime, Utc};
 
+use crate::domain::Id;
+
 #[derive(Debug, Clone)]
 pub struct Access {
-    source: String,
+    source: Id,
+    instance: Id,
     timestamp: DateTime<Utc>,
 }
 
 impl Access {
-    pub fn new(source: String, timestamp: DateTime<Utc>) -> Access {
-        Access { source, timestamp }
+    pub fn new(source: Id, instance: Id, timestamp: DateTime<Utc>) -> Access {
+        Access {
+            source,
+            instance,
+            timestamp,
+        }
     }
 
-    pub fn create(source: String) -> Access {
-        Access::new(source, Utc::now())
+    pub fn create(source: Id, instance: Id) -> Access {
+        Access::new(source, instance, Utc::now())
     }
 
-    pub fn source(&self) -> &str {
+    pub fn source(&self) -> &Id {
         &self.source
+    }
+
+    pub fn instance(&self) -> &Id {
+        &self.instance
     }
 
     pub fn timestamp(&self) -> &DateTime<Utc> {

--- a/configd/src/domain/access.rs
+++ b/configd/src/domain/access.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 
 use crate::domain::Id;
 
@@ -52,6 +52,14 @@ impl Access {
             Utc::now(),
             Some(self.timestamp),
         )
+    }
+
+    pub fn elapsed_time(&self) -> Duration {
+        Utc::now() - self.timestamp
+    }
+
+    pub fn elapsed_time_from_previous(&self) -> Option<Duration> {
+        self.previous.map(|previous| self.timestamp - previous)
     }
 }
 

--- a/configd/src/domain/config.rs
+++ b/configd/src/domain/config.rs
@@ -105,15 +105,15 @@ impl Config {
         &self.accesses
     }
 
-    pub fn register_access(&mut self, source: String) {
+    pub fn register_access(&mut self, source: Id, instance: Id) {
         if let Some(access) = self
             .accesses
             .iter_mut()
-            .find(|access| access.source() == source)
+            .find(|access| access.source() == &source && access.instance() == &instance)
         {
-            *access = Access::create(source);
+            *access = Access::create(source, instance);
         } else {
-            self.accesses.push(Access::create(source));
+            self.accesses.push(Access::create(source, instance));
         }
 
         self.accesses
@@ -146,39 +146,63 @@ mod tests {
         .unwrap();
 
         // New sources
-        config.register_access("Source 1".to_string());
-        config.register_access("Source 2".to_string());
+        config.register_access(
+            Id::new("Source 1").unwrap(),
+            Id::new("instance#01").unwrap(),
+        );
+        config.register_access(
+            Id::new("Source 2").unwrap(),
+            Id::new("instance#01").unwrap(),
+        );
 
-        assert_eq!(config.accesses()[0].source(), "Source 2");
-        assert_eq!(config.accesses()[1].source(), "Source 1");
+        assert_eq!(config.accesses()[0].source().value(), "Source 2");
+        assert_eq!(config.accesses()[1].source().value(), "Source 1");
 
         // Existing source
-        config.register_access("Source 1".to_string());
+        config.register_access(
+            Id::new("Source 1").unwrap(),
+            Id::new("instance#01").unwrap(),
+        );
 
-        assert_eq!(config.accesses()[0].source(), "Source 1");
-        assert_eq!(config.accesses()[1].source(), "Source 2");
+        assert_eq!(config.accesses()[0].source().value(), "Source 1");
+        assert_eq!(config.accesses()[1].source().value(), "Source 2");
 
         // New source
-        config.register_access("Source 3".to_string());
+        config.register_access(
+            Id::new("Source 3").unwrap(),
+            Id::new("instance#01").unwrap(),
+        );
 
         assert_eq!(config.accesses().len(), 3);
-        assert_eq!(config.accesses()[0].source(), "Source 3");
-        assert_eq!(config.accesses()[1].source(), "Source 1");
-        assert_eq!(config.accesses()[2].source(), "Source 2");
+        assert_eq!(config.accesses()[0].source().value(), "Source 3");
+        assert_eq!(config.accesses()[1].source().value(), "Source 1");
+        assert_eq!(config.accesses()[2].source().value(), "Source 2");
 
         // Save last accesses only
 
-        config.register_access("Source 4".to_string());
-        config.register_access("Source 5".to_string());
-        config.register_access("Source 6".to_string());
-        config.register_access("Source 7".to_string());
+        config.register_access(
+            Id::new("Source 4").unwrap(),
+            Id::new("instance#01").unwrap(),
+        );
+        config.register_access(
+            Id::new("Source 5").unwrap(),
+            Id::new("instance#01").unwrap(),
+        );
+        config.register_access(
+            Id::new("Source 6").unwrap(),
+            Id::new("instance#01").unwrap(),
+        );
+        config.register_access(
+            Id::new("Source 7").unwrap(),
+            Id::new("instance#01").unwrap(),
+        );
 
         assert_eq!(config.accesses().len(), 6);
-        assert_eq!(config.accesses()[0].source(), "Source 7");
-        assert_eq!(config.accesses()[1].source(), "Source 6");
-        assert_eq!(config.accesses()[2].source(), "Source 5");
-        assert_eq!(config.accesses()[3].source(), "Source 4");
-        assert_eq!(config.accesses()[4].source(), "Source 3");
-        assert_eq!(config.accesses()[5].source(), "Source 1");
+        assert_eq!(config.accesses()[0].source().value(), "Source 7");
+        assert_eq!(config.accesses()[1].source().value(), "Source 6");
+        assert_eq!(config.accesses()[2].source().value(), "Source 5");
+        assert_eq!(config.accesses()[3].source().value(), "Source 4");
+        assert_eq!(config.accesses()[4].source().value(), "Source 3");
+        assert_eq!(config.accesses()[5].source().value(), "Source 1");
     }
 }

--- a/configd/src/domain/config.rs
+++ b/configd/src/domain/config.rs
@@ -1,3 +1,4 @@
+use chrono::Duration;
 use core_lib::models::{Timestamps, Version};
 
 use crate::domain::{Access, Error, Id, Value};
@@ -118,6 +119,18 @@ impl Config {
 
         self.accesses
             .sort_by(|access1, access2| access2.timestamp().cmp(access1.timestamp()));
+
+        self.accesses.retain(|access| {
+            let max_duration = access
+                .elapsed_time_from_previous()
+                .map(|previous| {
+                    previous * 2
+                })
+                .unwrap_or_else(|| Duration::minutes(1));
+
+            access.elapsed_time() <= max_duration
+        });
+
         self.accesses.truncate(6);
     }
 

--- a/configd/src/domain/config.rs
+++ b/configd/src/domain/config.rs
@@ -111,7 +111,7 @@ impl Config {
             .iter_mut()
             .find(|access| access.source() == &source && access.instance() == &instance)
         {
-            *access = Access::create(source, instance);
+            *access = access.ping();
         } else {
             self.accesses.push(Access::create(source, instance));
         }

--- a/configd/src/domain/config.rs
+++ b/configd/src/domain/config.rs
@@ -123,10 +123,16 @@ impl Config {
         self.accesses.retain(|access| {
             let max_duration = access
                 .elapsed_time_from_previous()
-                .map(|previous| {
-                    previous * 2
+                .map(|mut previous| {
+                    previous = previous * 2;
+
+                    if previous.num_seconds() < 2 {
+                        previous = previous + Duration::seconds(1);
+                    }
+
+                    previous
                 })
-                .unwrap_or_else(|| Duration::minutes(1));
+                .unwrap_or_else(|| Duration::seconds(30));
 
             access.elapsed_time() <= max_duration
         });

--- a/configd/src/domain/events.rs
+++ b/configd/src/domain/events.rs
@@ -57,6 +57,7 @@ pub struct ConfigAccessed {
     pub id: String,
     pub schema_id: String,
     pub source: Option<String>,
+    pub instance: Option<String>,
 }
 
 impl Publishable for ConfigAccessed {

--- a/configd/src/domain/schema.rs
+++ b/configd/src/domain/schema.rs
@@ -133,17 +133,26 @@ impl Schema {
         Ok(())
     }
 
-    pub fn get_config(&mut self, id: &Id, source: Option<String>) -> Result<&Config, Error> {
+    pub fn get_config(
+        &mut self,
+        id: &Id,
+        source: Option<Id>,
+        instance: Option<Id>,
+    ) -> Result<&Config, Error> {
         if let Some(config) = self.configs.get_mut(id) {
             self.event_collector
                 .record(ConfigAccessed {
                     id: config.id().to_string(),
                     schema_id: self.id.to_string(),
-                    source: source.clone(),
+                    source: source.as_ref().map(|source| source.to_string()),
+                    instance: instance.as_ref().map(|instance| instance.to_string()),
                 })
                 .map_err(Error::Core)?;
 
-            config.register_access(source.unwrap_or_else(|| "unknown".to_string()));
+            config.register_access(
+                source.unwrap_or_else(|| Id::new("unknown").unwrap()),
+                instance.unwrap_or_else(|| Id::new("unknown").unwrap()),
+            );
 
             Ok(config)
         } else {

--- a/configd/src/handlers.rs
+++ b/configd/src/handlers.rs
@@ -160,11 +160,17 @@ pub async fn get_config_by_id(
             schema_id,
             config_id,
             source: headers
-                .get(header::ORIGIN)
-                .map(|origin| origin.to_str())
+                .get("X-Configd-Source")
+                .map(|header| header.to_str())
                 .transpose()
                 .unwrap_or(None)
-                .map(|origin| origin.to_string()),
+                .map(|header| header.to_string()),
+            instance: headers
+                .get("X-Configd-Instance")
+                .map(|header| header.to_str())
+                .transpose()
+                .unwrap_or(None)
+                .map(|header| header.to_string()),
         })
         .await?;
 

--- a/configd/src/infrastructure/sqlite_models.rs
+++ b/configd/src/infrastructure/sqlite_models.rs
@@ -64,6 +64,7 @@ impl SqliteConfig {
                         Id::new(access.source)?,
                         Id::new(access.instance)?,
                         access.timestamp,
+                        None,
                     ))
                 })
                 .collect::<Result<Vec<Access>, Error>>()?,

--- a/configd/src/infrastructure/sqlite_models.rs
+++ b/configd/src/infrastructure/sqlite_models.rs
@@ -12,6 +12,7 @@ pub struct SqliteAccess {
     pub source: String,
     pub instance: String,
     pub timestamp: DateTime<Utc>,
+    pub previous: Option<DateTime<Utc>>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -42,6 +43,7 @@ impl SqliteConfig {
                     source: access.source().to_string(),
                     instance: access.instance().to_string(),
                     timestamp: *access.timestamp(),
+                    previous: access.previous().copied(),
                 })
                 .collect(),
             created_at: *config.timestamps().created_at(),
@@ -64,7 +66,7 @@ impl SqliteConfig {
                         Id::new(access.source)?,
                         Id::new(access.instance)?,
                         access.timestamp,
-                        None,
+                        access.previous,
                     ))
                 })
                 .collect::<Result<Vec<Access>, Error>>()?,


### PR DESCRIPTION
- Use Id for source and instance.
- Extract source and instance from "X-Configd-Source" and
  "X-Configd-Instance" headers.
- fix: return checksum without hex::encode(..) conversion.