### PR TITLE
(feature): Splitted numbers between instances

### DIFF
--- a/configd/src/domain/prop.rs
+++ b/configd/src/domain/prop.rs
@@ -21,12 +21,14 @@ pub enum Prop {
         default_value: Option<Value>,
         allowed_values: Option<Vec<Value>>,
         interval: Option<Interval>,
+        split: bool,
     },
     Float {
         required: bool,
         default_value: Option<Value>,
         allowed_values: Option<Vec<Value>>,
         interval: Option<Interval>,
+        split: bool,
     },
     String {
         required: bool,
@@ -60,6 +62,7 @@ impl Prop {
         default_value: Option<Value>,
         allowed_values: Option<Vec<Value>>,
         interval: Option<Interval>,
+        split: bool,
     ) -> Result<Prop, Error> {
         if let Some(default_value) = &default_value {
             if default_value.kind() != Kind::Int {
@@ -86,6 +89,7 @@ impl Prop {
             default_value,
             allowed_values,
             interval,
+            split,
         })
     }
 
@@ -94,6 +98,7 @@ impl Prop {
         default_value: Option<Value>,
         allowed_values: Option<Vec<Value>>,
         interval: Option<Interval>,
+        split: bool,
     ) -> Result<Prop, Error> {
         if let Some(default_value) = &default_value {
             if default_value.kind() != Kind::Float {
@@ -120,6 +125,7 @@ impl Prop {
             default_value,
             allowed_values,
             interval,
+            split,
         })
     }
 
@@ -215,7 +221,7 @@ impl Prop {
         let mut diff = Diff::new(key);
 
         // Null values
-        if value == &Value::Null {
+        if value.is_null() {
             if self.is_required() && self.default_value().is_none() {
                 diff.add(Reason::NullValue, None);
             }
@@ -303,11 +309,16 @@ impl Prop {
         diff
     }
 
-    pub fn populate(&self, value: &Value) -> Value {
+    pub fn populate(&self, value: &Value, split_by: i64) -> Value {
         match self {
             Prop::Array(prop) => {
                 if let Value::Array(items) = value {
-                    return Value::Array(items.iter().map(|item| prop.populate(item)).collect());
+                    return Value::Array(
+                        items
+                            .iter()
+                            .map(|item| prop.populate(item, split_by))
+                            .collect(),
+                    );
                 }
             }
             Prop::Object(props) => {
@@ -320,7 +331,7 @@ impl Prop {
 
                                 (
                                     key.to_string(),
-                                    prop.map(|prop| prop.populate(item))
+                                    prop.map(|prop| prop.populate(item, split_by))
                                         .unwrap_or_else(|| item.clone()),
                                 )
                             })
@@ -331,11 +342,11 @@ impl Prop {
             _ => {}
         }
 
-        if value == &Value::Null {
-            if let Some(default_value) = self.default_value() {
-                return default_value.clone();
-            }
-        }
+        let value = if value.is_null() {
+            self.default_value().unwrap_or(value)
+        } else {
+            value
+        };
 
         value.clone()
     }
@@ -355,7 +366,7 @@ mod tests {
             .is_empty());
 
         // Required
-        assert!(Prop::int(false, None, None, None)
+        assert!(Prop::int(false, None, None, None, false)
             .unwrap()
             .validate(&Value::Null)
             .is_empty());
@@ -363,17 +374,21 @@ mod tests {
             .unwrap()
             .validate(&Value::Null)
             .is_empty());
-        assert!(Prop::array(Prop::int(true, None, None, None).unwrap())
-            .validate(&Value::Array(vec![Value::Int(12)]))
-            .is_empty());
-        assert!(Prop::array(Prop::int(false, None, None, None).unwrap())
-            .validate(&Value::Array(vec![Value::Null]))
-            .is_empty());
-        assert!(!Prop::int(true, None, None, None)
+        assert!(
+            Prop::array(Prop::int(true, None, None, None, false).unwrap())
+                .validate(&Value::Array(vec![Value::Int(12)]))
+                .is_empty()
+        );
+        assert!(
+            Prop::array(Prop::int(false, None, None, None, false).unwrap())
+                .validate(&Value::Array(vec![Value::Null]))
+                .is_empty()
+        );
+        assert!(!Prop::int(true, None, None, None, false)
             .unwrap()
             .validate(&Value::Null)
             .is_empty());
-        assert!(Prop::int(true, Some(Value::Int(32)), None, None)
+        assert!(Prop::int(true, Some(Value::Int(32)), None, None, false)
             .unwrap()
             .validate(&Value::Null)
             .is_empty());
@@ -381,12 +396,16 @@ mod tests {
             .unwrap()
             .validate(&Value::Null)
             .is_empty());
-        assert!(!Prop::array(Prop::int(true, None, None, None).unwrap())
-            .validate(&Value::Null)
-            .is_empty());
-        assert!(!Prop::array(Prop::int(true, None, None, None).unwrap())
-            .validate(&Value::Array(vec![Value::Null]))
-            .is_empty());
+        assert!(
+            !Prop::array(Prop::int(true, None, None, None, false).unwrap())
+                .validate(&Value::Null)
+                .is_empty()
+        );
+        assert!(
+            !Prop::array(Prop::int(true, None, None, None, false).unwrap())
+                .validate(&Value::Array(vec![Value::Null]))
+                .is_empty()
+        );
 
         // Allowed values
         assert!(Prop::string(
@@ -431,13 +450,13 @@ mod tests {
 
         // Interval
         assert!(
-            Prop::int(true, None, None, Some(Interval::new(1, 5).unwrap()))
+            Prop::int(true, None, None, Some(Interval::new(1, 5).unwrap()), false)
                 .unwrap()
                 .validate(&Value::Int(3))
                 .is_empty()
         );
         assert!(
-            !Prop::int(true, None, None, Some(Interval::new(1, 5).unwrap()))
+            !Prop::int(true, None, None, Some(Interval::new(1, 5).unwrap()), false)
                 .unwrap()
                 .validate(&Value::Int(6))
                 .is_empty()
@@ -496,7 +515,8 @@ mod tests {
                     ("prop1".to_string(), Prop::bool(true, None).unwrap()),
                     (
                         "prop2".to_string(),
-                        Prop::int(true, None, None, Some(Interval::new(1, 5).unwrap())).unwrap(),
+                        Prop::int(true, None, None, Some(Interval::new(1, 5).unwrap()), false)
+                            .unwrap(),
                     ),
                     (
                         "prop3".to_string(),
@@ -505,6 +525,7 @@ mod tests {
                             None,
                             Some(vec![Value::Float(1.0), Value::Float(3.0)]),
                             None,
+                            false,
                         )
                         .unwrap(),
                     ),
@@ -515,6 +536,7 @@ mod tests {
                             None,
                             Some(vec![Value::Float(1.0), Value::Float(3.0)]),
                             Some(Interval::new(1, 5).unwrap()),
+                            false,
                         )
                         .unwrap(),
                     ),
@@ -597,18 +619,18 @@ mod tests {
             ),
             (
                 "arr".to_string(),
-                Prop::array(Prop::int(false, Some(Value::Int(32)), None, None).unwrap()),
+                Prop::array(Prop::int(false, Some(Value::Int(32)), None, None, false).unwrap()),
             ),
             (
                 "obj".to_string(),
                 Prop::object(BTreeMap::from([
                     (
                         "float1".to_string(),
-                        Prop::float(true, Some(Value::Float(4.64)), None, None).unwrap(),
+                        Prop::float(true, Some(Value::Float(4.64)), None, None, false).unwrap(),
                     ),
                     (
                         "float2".to_string(),
-                        Prop::float(true, Some(Value::Float(3.23)), None, None).unwrap(),
+                        Prop::float(true, Some(Value::Float(3.23)), None, None, false).unwrap(),
                     ),
                 ])),
             ),
@@ -616,37 +638,40 @@ mod tests {
 
         // Not in prop tree
         assert_eq!(
-            prop.populate(&Value::String("str".to_string())),
+            prop.populate(&Value::String("str".to_string()), 1),
             Value::String("str".to_string()),
         );
 
-        assert_eq!(prop.populate(&Value::Null), Value::Null);
+        assert_eq!(prop.populate(&Value::Null, 1), Value::Null);
 
         // Populate all null properties
         assert_eq!(
-            prop.populate(&Value::Object(BTreeMap::from([
-                ("str1".to_string(), Value::Null),
-                ("str2".to_string(), Value::Null),
-                (
-                    "arr".to_string(),
-                    Value::Array(vec![
-                        Value::Int(2),
-                        Value::Float(4.0),
-                        Value::Null,
-                        Value::Int(16),
-                        Value::Null,
-                    ]),
-                ),
-                (
-                    "obj".to_string(),
-                    Value::Object(BTreeMap::from([
-                        ("float1".to_string(), Value::Null),
-                        ("float2".to_string(), Value::Null),
-                        ("float3".to_string(), Value::Null),
-                        ("float4".to_string(), Value::Float(1.23)),
-                    ])),
-                )
-            ]))),
+            prop.populate(
+                &Value::Object(BTreeMap::from([
+                    ("str1".to_string(), Value::Null),
+                    ("str2".to_string(), Value::Null),
+                    (
+                        "arr".to_string(),
+                        Value::Array(vec![
+                            Value::Int(2),
+                            Value::Float(4.0),
+                            Value::Null,
+                            Value::Int(16),
+                            Value::Null,
+                        ]),
+                    ),
+                    (
+                        "obj".to_string(),
+                        Value::Object(BTreeMap::from([
+                            ("float1".to_string(), Value::Null),
+                            ("float2".to_string(), Value::Null),
+                            ("float3".to_string(), Value::Null),
+                            ("float4".to_string(), Value::Float(1.23)),
+                        ])),
+                    )
+                ])),
+                1,
+            ),
             Value::Object(BTreeMap::from([
                 ("str1".to_string(), Value::String("str_default".to_string())),
                 ("str2".to_string(), Value::Null),

--- a/configd/src/domain/schema.rs
+++ b/configd/src/domain/schema.rs
@@ -365,18 +365,21 @@ mod tests {
         )
         .unwrap();
 
+        // Create config
         let config_id = Id::new("config-01").unwrap();
 
         schema
             .add_config(config_id.clone(), "Config 01".to_string(), Value::Null)
             .unwrap();
 
+        // Get config
         let config = schema.get_config(&config_id, None, None).unwrap();
 
         assert_eq!(config.id(), &config_id);
         assert_eq!(config.name(), "Config 01");
         assert_eq!(config.data(), &Value::Null);
 
+        // Populate data
         let data = schema.populate_config(&config);
         assert_eq!(data, Value::String("default".to_string()));
     }

--- a/configd/src/domain/schema.rs
+++ b/configd/src/domain/schema.rs
@@ -255,7 +255,8 @@ impl Schema {
     }
 
     pub fn populate_config(&self, config: &Config) -> Value {
-        self.root_prop.populate(config.data())
+        self.root_prop
+            .populate(config.data(), config.accesses().len() as i64)
     }
 }
 
@@ -303,7 +304,7 @@ mod tests {
                 ),
                 (
                     "num".to_string(),
-                    Prop::int(true, None, None, Some(Interval::new(1, 5).unwrap())).unwrap(),
+                    Prop::int(true, None, None, Some(Interval::new(1, 5).unwrap()), false).unwrap(),
                 ),
             ])),
         )

--- a/configd/src/domain/value.rs
+++ b/configd/src/domain/value.rs
@@ -59,6 +59,10 @@ impl Value {
         }
     }
 
+    pub fn is_null(&self) -> bool {
+        self == &Value::Null
+    }
+
     pub fn checksum(&self) -> String {
         let json: JsonValue = self.into();
 

--- a/go-lib/client.go
+++ b/go-lib/client.go
@@ -27,6 +27,8 @@ type ConfigdClient struct {
 
 	httpClient *http.Client
 	errCh      chan error
+
+	lastConfig *Config
 }
 
 func NewConfigdClient(
@@ -52,6 +54,7 @@ func NewConfigdClient(
 		instance,
 		http.DefaultClient,
 		make(chan error),
+		nil,
 	}, nil
 }
 
@@ -91,6 +94,15 @@ func (c *ConfigdClient) GetConfig(
 					c.notifyErr(err)
 					return
 				}
+
+				if c.lastConfig != nil {
+					if c.lastConfig.Checksum == config.Checksum &&
+						c.lastConfig.Version == config.Version {
+						continue
+					}
+				}
+
+				c.lastConfig = config
 
 				if err := configHandler(config, err); err != nil {
 					c.notifyErr(err)


### PR DESCRIPTION
`Value::Int(..)` and `Value::Float(..)` can be split between `Config` instances when setting `split = true` from `Schema`.